### PR TITLE
fix: use an secure link to g8c website

### DIFF
--- a/index.md
+++ b/index.md
@@ -28,7 +28,7 @@ feature_row:
              rassemble environ 500 participant(e)s.
              Elle est organisée par l'ensemble des Choucas
              pour faire partager notre passion et nos chemins.
-    url:     http://www.g8c.fr/
+    url:     https://grand8cellois.github.io/
     btn_label: Le site du Grand Huit Cellois
 ---
 


### PR DESCRIPTION
https is not functional for www.g8c.fr, so let's use the final target directly